### PR TITLE
Add callable table recognition helper API

### DIFF
--- a/table_ocr_tool/README.md
+++ b/table_ocr_tool/README.md
@@ -1,0 +1,68 @@
+# 表格识别工具
+
+该目录提供一个独立的 Python 脚本 `table_ocr_tool.py`，用于在 PandaOCR 项目中快速体验表格识别功能。脚本基于「线框检测 + OCR」思路，将表格截图拆分成单元格并输出 CSV 或 JSON 结果，方便后续导入到 Excel、Notion 等工具。
+
+## 功能特性
+- **自动检测表格结构**：使用 OpenCV 对横线和竖线进行形态学处理，推断表格单元格布局。
+- **多 OCR 引擎支持**：优先调用 [`rapidocr-onnxruntime`](https://github.com/RapidAI/RapidOCR)，若未安装则回退到 [`pytesseract`](https://github.com/madmaze/pytesseract)。
+- **多种输出格式**：支持 CSV（二维表格）和 JSON（包含坐标与文本的结构化信息）。
+- **无侵入集成**：脚本与 PandaOCR 主程序解耦，可单独运行或与已有工作流组合。
+
+## 环境依赖
+- Python 3.9+
+- [opencv-python](https://pypi.org/project/opencv-python/)
+- [numpy](https://pypi.org/project/numpy/)
+- 以下 OCR 后端二选一：
+  - [rapidocr-onnxruntime](https://pypi.org/project/rapidocr-onnxruntime/)（默认优先）
+  - [pytesseract](https://pypi.org/project/pytesseract/) + [Tesseract OCR](https://github.com/tesseract-ocr/tesseract)
+
+```bash
+pip install opencv-python numpy rapidocr-onnxruntime
+# 或者
+pip install opencv-python numpy pytesseract
+```
+
+> 若使用 `pytesseract`，请根据操作系统安装 Tesseract 主程序，并确保其在系统 PATH 中。
+
+## 快速上手
+```bash
+python table_ocr_tool.py --image ./samples/table.png --csv table.csv --json table.json
+```
+
+- `--image`：表格截图路径。
+- `--csv`：输出 CSV 文件路径（可选）。
+- `--json`：输出 JSON 文件路径（可选）。
+- `--backend`：指定 OCR 后端，可多次传入（如 `--backend rapidocr --backend tesseract`）。
+- `--debug`：输出调试日志，观察单元格识别细节。
+
+当不指定 `--csv`/`--json` 时，脚本会在控制台逐行打印 `[row, col] 文本` 结果，适合快速验证。
+
+## 在代码中调用
+
+如果不想通过命令行参数运行，可在其他脚本中直接调用 `run_table_recognition`：
+
+```python
+from table_ocr_tool.table_ocr_tool import run_table_recognition
+
+cells = run_table_recognition("./samples/table.png")
+for cell in cells:
+    print(cell.row, cell.column, cell.text)
+```
+
+`run_table_recognition` 会读取 `image` 路径指向的图片（或直接接受 `numpy.ndarray` 图像），返回包含行列、坐标与文本的 `Cell` 对象列表。根据需要还可以同时传入 `csv_path`/`json_path`，在不依赖命令行的情况下导出识别结果。
+
+## 工作流程
+1. 读入图像并转为灰度图，应用自适应阈值生成二值图。
+2. 使用形态学腐蚀/膨胀分别提取横线与竖线，合并获得表格线框。
+3. 通过轮廓检测获取单元格候选框，按行列排序。
+4. 对每个单元格裁剪图像，调用 OCR 引擎识别文本。
+5. 根据需要导出 CSV 或 JSON。
+
+## 与 PandaOCR 联动思路
+- 可将脚本输出的 CSV 作为 PandaOCR 识别后的后处理步骤，例如在监听剪贴板模式下保存截图，再批处理识别。
+- 针对特定接口（如百度/腾讯表格识别 API），可改写 `OCRBackend` 以对接 HTTP 服务，实现更高精度或批量处理。
+
+欢迎根据自身需求扩展，例如：
+- 加入自定义阈值、行列合并逻辑。
+- 对接更多 OCR 引擎或自训练模型。
+- 集成 GUI 以便在 Windows 上一键处理表格截图。

--- a/table_ocr_tool/table_ocr_tool.py
+++ b/table_ocr_tool/table_ocr_tool.py
@@ -1,0 +1,294 @@
+"""Command line utility for table recognition based on OCR.
+
+This module provides a thin wrapper around OpenCV + Tesseract style
+processing so that PandaOCR users can batch convert table screenshots into
+structured CSV/JSON outputs.  The implementation focuses on being easy to
+understand and customise rather than being a drop-in replacement for heavy
+frameworks.
+
+Typical usage::
+
+    python table_ocr_tool.py --image demo.png --csv demo.csv
+
+The script detects horizontal/vertical ruling lines, segments the image into
+cells and runs OCR for each cell.  Text recognition requires either
+``pytesseract`` or ``rapidocr-onnxruntime``.  When both are available,
+RapidOCR is used because it performs better on multilingual text.
+
+The module intentionally keeps dependencies optional.  Each backend is only
+imported when requested at runtime.  When neither backend can be imported the
+script raises a :class:`RuntimeError` with installation hints.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Sequence, Tuple, Union
+
+try:
+    import cv2  # type: ignore
+    import numpy as np  # type: ignore
+except ImportError as exc:  # pragma: no cover - optional dependency guard
+    raise RuntimeError(
+        "table_ocr_tool requires 'opencv-python' and 'numpy'.\n"
+        "Install them via 'pip install opencv-python numpy'."
+    ) from exc
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class Cell:
+    """Represents a detected table cell."""
+
+    row: int
+    column: int
+    bbox: Tuple[int, int, int, int]
+    text: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "row": self.row,
+            "column": self.column,
+            "bbox": self.bbox,
+            "text": self.text,
+        }
+
+
+class OCRBackend:
+    """Abstract base class for OCR engines."""
+
+    def recognise(self, image: "np.ndarray") -> str:
+        raise NotImplementedError
+
+
+class RapidOCRBackend(OCRBackend):
+    """OCR backend using rapidocr_onnxruntime."""
+
+    def __init__(self) -> None:
+        from rapidocr_onnxruntime import RapidOCR  # type: ignore
+
+        self._ocr = RapidOCR()
+
+    def recognise(self, image: "np.ndarray") -> str:
+        result, _ = self._ocr(image)
+        if not result:
+            return ""
+        return " ".join(item[1] for item in result)
+
+
+class TesseractBackend(OCRBackend):
+    """OCR backend using pytesseract."""
+
+    def __init__(self) -> None:
+        import pytesseract  # type: ignore
+
+        self._tesseract = pytesseract
+
+    def recognise(self, image: "np.ndarray") -> str:
+        return self._tesseract.image_to_string(image, config="--psm 6").strip()
+
+
+def _load_ocr_backend(preferred: Sequence[str]) -> OCRBackend:
+    last_error = None
+    for name in preferred:
+        try:
+            if name == "rapidocr":
+                return RapidOCRBackend()
+            if name == "tesseract":
+                return TesseractBackend()
+        except Exception as exc:  # pragma: no cover - runtime import errors
+            last_error = exc
+            _LOGGER.debug("Failed to initialise %s backend: %s", name, exc)
+    raise RuntimeError(
+        "No OCR backend is available.\n"
+        "Install 'rapidocr-onnxruntime' or 'pytesseract'."
+    ) from last_error
+
+
+def _binarise(image: "np.ndarray") -> "np.ndarray":
+    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    blur = cv2.GaussianBlur(gray, (5, 5), 0)
+    return cv2.adaptiveThreshold(
+        blur, 255, cv2.ADAPTIVE_THRESH_MEAN_C, cv2.THRESH_BINARY_INV, 25, 10
+    )
+
+
+def _extract_table_mask(binary: "np.ndarray") -> Tuple["np.ndarray", "np.ndarray"]:
+    horizontal_kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (binary.shape[1] // 30, 1))
+    vertical_kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (1, binary.shape[0] // 30))
+
+    horizontal_lines = cv2.erode(binary, horizontal_kernel, iterations=1)
+    horizontal_lines = cv2.dilate(horizontal_lines, horizontal_kernel, iterations=1)
+
+    vertical_lines = cv2.erode(binary, vertical_kernel, iterations=1)
+    vertical_lines = cv2.dilate(vertical_lines, vertical_kernel, iterations=1)
+
+    return horizontal_lines, vertical_lines
+
+
+def _detect_cells(binary: "np.ndarray") -> List[Tuple[int, int, int, int]]:
+    horizontal_lines, vertical_lines = _extract_table_mask(binary)
+    table_mask = cv2.add(horizontal_lines, vertical_lines)
+    contours, _ = cv2.findContours(table_mask, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
+
+    boxes: List[Tuple[int, int, int, int]] = []
+    for contour in contours:
+        x, y, w, h = cv2.boundingRect(contour)
+        if w < 10 or h < 10:
+            continue
+        boxes.append((x, y, w, h))
+
+    boxes.sort(key=lambda box: (box[1], box[0]))
+    return boxes
+
+
+def _cluster_rows(boxes: Sequence[Tuple[int, int, int, int]], tolerance: int = 10) -> List[List[Tuple[int, int, int, int]]]:
+    rows: List[List[Tuple[int, int, int, int]]] = []
+    for box in boxes:
+        x, y, w, h = box
+        if not rows:
+            rows.append([box])
+            continue
+        last_row = rows[-1]
+        _, last_y, _, last_h = last_row[0]
+        if abs(y - last_y) <= tolerance or abs((y + h) - (last_y + last_h)) <= tolerance:
+            last_row.append(box)
+        else:
+            rows.append([box])
+
+    for row in rows:
+        row.sort(key=lambda item: item[0])
+    return rows
+
+
+def _load_image(image_source: Union[str, Path, "np.ndarray"]) -> "np.ndarray":
+    if isinstance(image_source, (str, Path)):
+        image_path = Path(image_source)
+        image = cv2.imread(str(image_path))
+        if image is None:
+            raise FileNotFoundError(f"Unable to load image: {image_path}")
+        return image
+    if isinstance(image_source, np.ndarray):
+        return image_source
+    raise TypeError(
+        "image_source must be a path-like object or an ndarray."
+    )
+
+
+def recognise_table(
+    image_source: Union[str, Path, "np.ndarray"],
+    backend_priority: Sequence[str] | None = None,
+) -> List[Cell]:
+    image = _load_image(image_source)
+
+    binary = _binarise(image)
+    boxes = _detect_cells(binary)
+    rows = _cluster_rows(boxes)
+
+    backend = _load_ocr_backend(backend_priority or ("rapidocr", "tesseract"))
+
+    cells: List[Cell] = []
+    for row_idx, row in enumerate(rows):
+        for col_idx, (x, y, w, h) in enumerate(row):
+            cell_image = image[y : y + h, x : x + w]
+            text = backend.recognise(cell_image)
+            cells.append(Cell(row=row_idx, column=col_idx, bbox=(x, y, w, h), text=text))
+    return cells
+
+
+def _write_csv(cells: Sequence[Cell], output_path: Path) -> None:
+    if not cells:
+        output_path.write_text("")
+        return
+
+    max_row = max(cell.row for cell in cells)
+    max_col = max(cell.column for cell in cells)
+
+    table: List[List[str]] = [["" for _ in range(max_col + 1)] for _ in range(max_row + 1)]
+    for cell in cells:
+        table[cell.row][cell.column] = cell.text
+
+    with output_path.open("w", encoding="utf-8", newline="") as fp:
+        writer = csv.writer(fp)
+        writer.writerows(table)
+
+
+def _write_json(cells: Sequence[Cell], output_path: Path) -> None:
+    data = [cell.to_dict() for cell in cells]
+    output_path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def run_table_recognition(
+    image_source: Union[str, Path, "np.ndarray"],
+    *,
+    csv_path: Union[str, Path, None] = None,
+    json_path: Union[str, Path, None] = None,
+    backend_priority: Sequence[str] | None = None,
+) -> List[Cell]:
+    """Recognise a table and optionally export CSV/JSON results.
+
+    该函数提供比命令行更易嵌入的接口，可以在其他模块中直接传入
+    图片路径或 `numpy.ndarray` 图像数组，返回识别出的单元格列表。
+    当指定 `csv_path` 或 `json_path` 时，会同步写出对应的结果文件。
+    """
+
+    cells = recognise_table(image_source, backend_priority=backend_priority)
+
+    if csv_path is not None:
+        _write_csv(cells, Path(csv_path))
+    if json_path is not None:
+        _write_json(cells, Path(json_path))
+
+    return cells
+
+
+def parse_args(args: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Table recognition helper for PandaOCR")
+    parser.add_argument("--image", required=True, type=Path, help="Path to the input table screenshot")
+    parser.add_argument("--csv", type=Path, help="Optional CSV output path")
+    parser.add_argument("--json", type=Path, help="Optional JSON output path")
+    parser.add_argument(
+        "--backend",
+        choices=["rapidocr", "tesseract"],
+        action="append",
+        help=(
+            "Preferred OCR backend(s).  Can be supplied multiple times.  When omitted, "
+            "the tool tries rapidocr first and falls back to pytesseract."
+        ),
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable verbose logging")
+    return parser.parse_args(args)
+
+
+def main(cli_args: Sequence[str] | None = None) -> int:
+    args = parse_args(cli_args)
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
+
+    cells = run_table_recognition(
+        args.image,
+        csv_path=args.csv,
+        json_path=args.json,
+        backend_priority=args.backend,
+    )
+
+    if args.csv:
+        _LOGGER.info("CSV exported to %s", args.csv)
+    if args.json:
+        _LOGGER.info("JSON exported to %s", args.json)
+
+    for cell in cells:
+        _LOGGER.debug("Cell r%d c%d: %s", cell.row, cell.column, cell.text)
+
+    if not (args.csv or args.json):
+        for cell in cells:
+            print(f"[{cell.row}, {cell.column}] {cell.text}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- allow `recognise_table` to accept image paths or NumPy arrays by adding a shared loader
- add `run_table_recognition` helper for programmatic CSV/JSON export without CLI usage
- document the programmatic workflow for importing the helper in README

## Testing
- python -m compileall table_ocr_tool/table_ocr_tool.py

------
https://chatgpt.com/codex/tasks/task_e_68cacb6884f4832bbf7eb245513b4103