### PR TITLE
feat: add paddleocr command line tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,31 @@
 
 ------------
 
+### 命令行OCR工具（PaddleOCR）
+
+仓库新增 `paddle_ocr_app` 模块，提供一个基于 [PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR) 的轻量级命令行识别工具，可批量识别图片、导出文本/JSON并生成可视化标注图。
+
+**准备工作**
+
+```bash
+pip install paddlepaddle paddleocr pillow
+```
+
+根据设备选择合适的 `paddlepaddle` 版本即可，CPU/GPU 环境均支持。
+
+**使用示例**
+
+```bash
+python -m paddle_ocr_app tests/demo.png --output result.txt --json result.json --visualize visualize/
+```
+
+- 支持一次传入多个文件或文件夹，配合 `--recursive` 递归遍历图片。
+- 通过 `--min-confidence` 可以过滤低置信度结果，默认保留全部识别内容。
+- `--visualize` 会在指定目录输出叠加检测框的图片，可选 `--font` 指定中文字体，提升渲染效果。
+- 如果有自定义的模型文件，可分别使用 `--det-model-dir`、`--rec-model-dir`、`--cls-model-dir` 进行覆盖。
+
+------------
+
 #### 特别声明：
 - 本工具一直只在Github发布和更新，目前并没有所谓PandaOCR官网或熊猫OCR官网，从其他网站下载的PandaOCR请自行验证安全性！
 - 目前发现这个免费软件居然被有些可能生活困难的朋友拿到某宝上出售，导致买去用的人反而跑来找我当售后（这不厚道），这太难了，建议买的人找店主解决！

--- a/paddle_ocr_app/__init__.py
+++ b/paddle_ocr_app/__init__.py
@@ -1,0 +1,108 @@
+"""PaddleOCR命令行工具的核心API。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Sequence
+
+
+@dataclass
+class OCRLine:
+    """表示一条OCR识别结果。"""
+
+    text: str
+    confidence: float
+    bbox: List[tuple[float, float]]
+
+    def to_dict(self) -> dict:
+        return {
+            "text": self.text,
+            "confidence": self.confidence,
+            "bbox": [[float(x), float(y)] for x, y in self.bbox],
+        }
+
+
+@dataclass
+class OCRResult:
+    """单张图片的识别结果。"""
+
+    image_path: Path
+    lines: List[OCRLine]
+
+    def to_dict(self) -> dict:
+        return {
+            "image": str(self.image_path),
+            "lines": [line.to_dict() for line in self.lines],
+        }
+
+    def to_text(self, joiner: str = "\n") -> str:
+        return joiner.join(line.text for line in self.lines)
+
+    def filtered(self, min_confidence: float) -> "OCRResult":
+        if min_confidence <= 0:
+            return self
+        filtered_lines = [line for line in self.lines if line.confidence >= min_confidence]
+        if len(filtered_lines) == len(self.lines):
+            return self
+        return OCRResult(image_path=self.image_path, lines=filtered_lines)
+
+
+class PaddleOCRService:
+    """封装PaddleOCR识别流程。"""
+
+    def __init__(
+        self,
+        *,
+        lang: str = "ch",
+        use_gpu: bool = False,
+        use_angle_cls: bool = True,
+        show_log: bool = False,
+        **paddle_kwargs,
+    ) -> None:
+        try:
+            from paddleocr import PaddleOCR  # type: ignore
+        except ImportError as exc:  # pragma: no cover - 依赖缺失时提示
+            raise RuntimeError(
+                "PaddleOCRService需要'paddleocr'库，请先运行: pip install paddleocr"
+            ) from exc
+
+        if "use_angle_cls" not in paddle_kwargs:
+            paddle_kwargs["use_angle_cls"] = use_angle_cls
+        if "show_log" not in paddle_kwargs:
+            paddle_kwargs["show_log"] = show_log
+
+        self._use_angle_cls = bool(paddle_kwargs.get("use_angle_cls", use_angle_cls))
+        self._ocr = PaddleOCR(lang=lang, use_gpu=use_gpu, **paddle_kwargs)
+
+    def run(self, image_path: Path) -> OCRResult:
+        if not image_path.exists():
+            raise FileNotFoundError(f"未找到图片文件: {image_path}")
+        if not image_path.is_file():
+            raise FileNotFoundError(f"路径不是文件: {image_path}")
+
+        raw_result = self._ocr.ocr(str(image_path), cls=self._use_angle_cls)
+
+        def _is_line(entry: object) -> bool:
+            if not isinstance(entry, (list, tuple)) or len(entry) != 2:
+                return False
+            points, payload = entry
+            return isinstance(points, (list, tuple)) and isinstance(payload, (list, tuple))
+
+        if raw_result and isinstance(raw_result[0], list) and not _is_line(raw_result[0]) and raw_result[0]:
+            first_item = raw_result[0][0]
+            if _is_line(first_item):
+                raw_result = raw_result[0]
+
+        lines: List[OCRLine] = []
+        for item in raw_result or []:
+            if not item or len(item) < 2:
+                continue
+            points = item[0]
+            text, confidence = item[1]
+            bbox = [(float(x), float(y)) for x, y in points]
+            lines.append(OCRLine(text=text, confidence=float(confidence), bbox=bbox))
+        return OCRResult(image_path=image_path, lines=lines)
+
+    def run_batch(self, image_paths: Sequence[Path]) -> List[OCRResult]:
+        return [self.run(path) for path in image_paths]

--- a/paddle_ocr_app/__main__.py
+++ b/paddle_ocr_app/__main__.py
@@ -1,0 +1,7 @@
+"""允许通过 `python -m paddle_ocr_app` 直接运行命令行工具。"""
+from __future__ import annotations
+
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover - 入口点
+    raise SystemExit(main())

--- a/paddle_ocr_app/cli.py
+++ b/paddle_ocr_app/cli.py
@@ -1,0 +1,183 @@
+"""PaddleOCR命令行工具。"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+from . import OCRResult, PaddleOCRService
+
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff", ".webp"}
+
+
+def _confidence(value: str) -> float:
+    try:
+        result = float(value)
+    except ValueError as exc:  # pragma: no cover - argparse会处理
+        raise argparse.ArgumentTypeError("请输入合法的浮点数") from exc
+    if not 0.0 <= result <= 1.0:
+        raise argparse.ArgumentTypeError("置信度阈值需要在0~1之间")
+    return result
+
+
+def _collect_image_paths(inputs: Sequence[Path], recursive: bool) -> List[Path]:
+    images: List[Path] = []
+    seen = set()
+    for input_path in inputs:
+        if not input_path.exists():
+            raise FileNotFoundError(f"未找到路径: {input_path}")
+        if input_path.is_file():
+            if input_path.suffix.lower() in IMAGE_EXTENSIONS:
+                if input_path not in seen:
+                    seen.add(input_path)
+                    images.append(input_path)
+            else:
+                logging.warning("忽略不支持的文件: %s", input_path)
+            continue
+
+        iterator: Iterable[Path]
+        iterator = input_path.rglob("*") if recursive else input_path.glob("*")
+        for candidate in iterator:
+            if candidate.is_file() and candidate.suffix.lower() in IMAGE_EXTENSIONS:
+                if candidate not in seen:
+                    seen.add(candidate)
+                    images.append(candidate)
+    return images
+
+
+def _print_result(result: OCRResult) -> None:
+    header = f"===== {result.image_path} ====="
+    print(header)
+    if not result.lines:
+        print("未识别到文本。\n")
+        return
+    for line in result.lines:
+        print(f"[{line.confidence:.0%}] {line.text}")
+    print()
+
+
+def _write_text(results: Sequence[OCRResult], output_path: Path) -> None:
+    with output_path.open("w", encoding="utf-8") as fp:
+        for index, result in enumerate(results):
+            fp.write(f"# {result.image_path}\n")
+            if result.lines:
+                fp.write(result.to_text("\n"))
+                fp.write("\n")
+            if index != len(results) - 1:
+                fp.write("\n")
+
+
+def _write_json(results: Sequence[OCRResult], output_path: Path) -> None:
+    payload = [result.to_dict() for result in results]
+    output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _visualize_result(result: OCRResult, output_dir: Path, font_path: Path | None) -> Path:
+    if not result.lines:
+        raise ValueError("当前图片没有识别结果，无法生成可视化。")
+
+    try:
+        from paddleocr import draw_ocr  # type: ignore
+        from PIL import Image  # type: ignore
+    except ImportError as exc:  # pragma: no cover - 依赖缺失
+        raise RuntimeError("生成可视化需要安装'pillow'依赖: pip install pillow") from exc
+
+    image = Image.open(result.image_path).convert("RGB")
+    boxes = [line.bbox for line in result.lines]
+    texts = [line.text for line in result.lines]
+    scores = [line.confidence for line in result.lines]
+    im_show = draw_ocr(image, boxes, texts, scores, font_path=str(font_path) if font_path else None)
+    annotated = Image.fromarray(im_show)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / f"{result.image_path.stem}_ocr.png"
+    annotated.save(output_path)
+    return output_path
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="基于PaddleOCR的轻量级识别工具")
+    parser.add_argument("inputs", nargs="+", type=Path, help="图片文件或文件夹，可以一次传入多个")
+    parser.add_argument("--lang", default="ch", help="PaddleOCR的语言代码，例如ch、en")
+    parser.add_argument("--use-gpu", action="store_true", help="使用GPU进行识别")
+    parser.add_argument("--recursive", action="store_true", help="递归遍历文件夹中的图片")
+    parser.add_argument("--min-confidence", type=_confidence, default=0.0, help="过滤低于阈值的识别结果")
+    parser.add_argument("--limit", type=int, help="仅处理指定数量的图片")
+    parser.add_argument("--output", type=Path, help="将纯文本结果写入指定文件")
+    parser.add_argument("--json", dest="json_path", type=Path, help="将结构化结果保存为JSON文件")
+    parser.add_argument("--visualize", type=Path, help="输出识别标注图像的目录")
+    parser.add_argument("--font", type=Path, help="可视化文字使用的字体文件路径")
+    parser.add_argument("--det-model-dir", type=Path, help="自定义检测模型目录")
+    parser.add_argument("--rec-model-dir", type=Path, help="自定义识别模型目录")
+    parser.add_argument("--cls-model-dir", type=Path, help="自定义方向分类模型目录")
+    parser.add_argument("--debug", action="store_true", help="显示调试日志")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO, format="%(levelname)s: %(message)s")
+
+    try:
+        image_paths = _collect_image_paths(args.inputs, args.recursive)
+    except FileNotFoundError as exc:
+        logging.error("%s", exc)
+        return 1
+
+    if not image_paths:
+        logging.error("未找到任何可识别的图片。")
+        return 1
+
+    if args.limit is not None and args.limit >= 0:
+        image_paths = image_paths[: args.limit]
+
+    paddle_kwargs = {}
+    if args.det_model_dir:
+        paddle_kwargs["det_model_dir"] = str(args.det_model_dir)
+    if args.rec_model_dir:
+        paddle_kwargs["rec_model_dir"] = str(args.rec_model_dir)
+    if args.cls_model_dir:
+        paddle_kwargs["cls_model_dir"] = str(args.cls_model_dir)
+
+    try:
+        service = PaddleOCRService(
+            lang=args.lang,
+            use_gpu=args.use_gpu,
+            show_log=args.debug,
+            **paddle_kwargs,
+        )
+    except RuntimeError as exc:
+        logging.error("%s", exc)
+        return 1
+
+    results: List[OCRResult] = []
+    for path in image_paths:
+        logging.info("开始识别: %s", path)
+        try:
+            result = service.run(path)
+        except Exception as exc:  # pragma: no cover - 运行时错误
+            logging.error("识别失败 %s: %s", path, exc)
+            continue
+        filtered_result = result.filtered(args.min_confidence)
+        results.append(filtered_result)
+        _print_result(filtered_result)
+
+        if args.visualize:
+            try:
+                saved_path = _visualize_result(filtered_result, args.visualize, args.font)
+            except Exception as exc:  # pragma: no cover - 可视化失败
+                logging.warning("生成可视化失败 %s: %s", path, exc)
+            else:
+                logging.info("可视化结果已保存: %s", saved_path)
+
+    if args.output and results:
+        _write_text(results, args.output)
+        logging.info("文本结果已写入: %s", args.output)
+
+    if args.json_path and results:
+        _write_json(results, args.json_path)
+        logging.info("JSON结果已写入: %s", args.json_path)
+
+    return 0 if results else 2


### PR DESCRIPTION
## Summary
- add a new `paddle_ocr_app` Python module that wraps PaddleOCR into a reusable service and command line entry point
- document installation and usage instructions for the PaddleOCR-based CLI in the README

## Testing
- python -m paddle_ocr_app --help

------
https://chatgpt.com/codex/tasks/task_e_68ce0b731ea8832b8d1049d4f8f03e98